### PR TITLE
Add support for MilesBobsExpansion tier 7-10 machines.

### DIFF
--- a/info.json
+++ b/info.json
@@ -12,6 +12,7 @@
     "? bobplates >= 1.1.2",
     "? bobpower >= 1.1.1",
     "? bobtech >= 1.1.2",
+    "? MilesBobsExpansion",
     "? Krastorio2 >= 0.9.14"
   ],
   "description": "New tiers of entities that come with integrated requester and provider chests and a substation.  Now works with Bob's Mods and Krastorio2 entities!"

--- a/prototypes/entity/assembling-machine.lua
+++ b/prototypes/entity/assembling-machine.lua
@@ -28,4 +28,12 @@ else
         createMachine(5),
         createMachine(6),
     })
+    if mods["MilesBobsExpansion"] then
+        data:extend({
+            createMachine(7),
+            createMachine(8),
+            createMachine(9),
+            createMachine(10),
+        })
+    end
 end

--- a/prototypes/item/assembling-machine.lua
+++ b/prototypes/item/assembling-machine.lua
@@ -25,4 +25,12 @@ else
         createMachine(5),
         createMachine(6),
     })
+    if mods["MilesBobsExpansion"] then
+        data:extend({
+            createMachine(7),
+            createMachine(8),
+            createMachine(9),
+            createMachine(10)
+        })
+    end
 end


### PR DESCRIPTION
Just a simple addition to add Logistic variants of the tier 7-10 machines added by MilesBobsExpansion.